### PR TITLE
Change error message to match Scratch error message

### DIFF
--- a/src/routes/users/[user].ts
+++ b/src/routes/users/[user].ts
@@ -6,7 +6,7 @@ export default async function (req: Request, res: Response) {
     const user = await client.from("users").select().eq("username", req.params.user);
 
     if (user.data.length === 0) {
-        return res.json(404, { code: "NotFound", "message": "User not found" });
+        return res.json(404, { code: "ResourceNotFound", "message": `${req.path} does not exist`});
     } else if (user.error) {
         return res.json(500, { code: "InternalServerError", "message": "Error fetching user" });
     }


### PR DESCRIPTION
Currently, the 404 message does not match Scratch’s error message. Assuming this is basically a deconstructed version of the API I decided to try to fix this. Let me know if it doesn’t work, I can fix it.